### PR TITLE
Fix for 3px square image, add object output option

### DIFF
--- a/lib/bitmap.js
+++ b/lib/bitmap.js
@@ -53,7 +53,7 @@ Bitmap.prototype.isBitmap = function(){
   }
   return false;
 };
-Bitmap.prototype.getData = function (){
+Bitmap.prototype.getData = function (asRgbObj){
   this.checkInit();
 
   if(this.COMPRESSION_BI_RGB !== this.coreHeader.__copmression__){
@@ -64,17 +64,16 @@ Bitmap.prototype.getData = function (){
   var width = this.getWidth();
   var height = this.getHeight();
 
-  var line = (width * bitCount) / 8;
-  if(0 != (line % 4)){
-    line = ((line / 4) + 1) * 4;
-  }
+  var lineRaw = width * bitCount / 8,
+    // ensure padded to DWORD (32bits)
+    line = lineRaw + ((lineRaw % 4) ? (4 - (lineRaw % 4)) : 0);
 
   var rgbaData = [];
   var dataPos = this.dataPos;
   for(var i = 0; i < height; ++i) {
     var pos = dataPos + (line * (height - (i + 1)));
-    var buf = this.buffer.slice(pos, pos + line);
-    var color = this.mapColor(buf, bitCount);
+    var buf = this.buffer.slice(pos, pos + lineRaw);
+    var color = this.mapColor(buf, bitCount, asRgbObj);
     rgbaData.push(color);
   }
   return rgbaData;
@@ -513,10 +512,10 @@ Bitmap.prototype.initDataPos = function(){
     throw new Error('unknown colorPalette: ' + coreType + ',' + bitCount);
   }
 };
-Bitmap.prototype.mapRGBA = function(r, g, b, a){
+Bitmap.prototype.mapRGBA = function(r, g, b, a, asRgbObj){
   var hex = [];
 
-  var padHex = function(value){
+  var padHex = function(value, asRgbObj){
     var h = value.toString(16);
     if(value < 0x0f){
       return '0' + h;
@@ -524,13 +523,21 @@ Bitmap.prototype.mapRGBA = function(r, g, b, a){
     return h;
   };
 
+  if(asRgbObj){
+    hex = { r:r, g:g, b:b };
+    if( a >= 0 ){
+      hex.a = a;
+    }
+    return hex;
+  }
+  
   hex.push(padHex(r));
   hex.push(padHex(g));
   hex.push(padHex(b));
 
   return '#' + hex.join('');
 };
-Bitmap.prototype.mapColor = function(bmpBuf, bitCount){
+Bitmap.prototype.mapColor = function(bmpBuf, bitCount, asRgbObj){
   var b, g, r, a;
   var length = bmpBuf.length;
   var colorData = [];
@@ -544,7 +551,7 @@ Bitmap.prototype.mapColor = function(bmpBuf, bitCount){
       for(var j = 0; j < bin.length; ++j){
         var paletteIndex = parseInt(bin.substring(j, j + 1), 10);
         var palette = this.colorPalette[paletteIndex];
-        colorData.push(this.mapRGBA(palette.rgbRed, palette.rgbGreen, palette.rgbBlue, -1));
+        colorData.push(this.mapRGBA(palette.rgbRed, palette.rgbGreen, palette.rgbBlue, -1, asRgbObj));
       }
     }
     return colorData;
@@ -556,7 +563,7 @@ Bitmap.prototype.mapColor = function(bmpBuf, bitCount){
       var indexes = [paletteHigh, paletteLow];
       indexes.forEach(function(paletteIndex){
         var palette = this.colorPalette[paletteIndex];
-        colorData.push(this.mapRGBA(palette.rgbRed, palette.rgbGreen, palette.rgbBlue, -1));
+        colorData.push(this.mapRGBA(palette.rgbRed, palette.rgbGreen, palette.rgbBlue, -1, asRgbObj));
       });
     }
 
@@ -566,7 +573,7 @@ Bitmap.prototype.mapColor = function(bmpBuf, bitCount){
     for(var i = 0; i < length; ++i){
       var paletteIndex = bmpBuf.readUInt16LE(i);
       var palette = this.colorPalette[paletteIndex];
-      colorData.push(this.mapRGBA(palette.rgbRed, palette.rgbGreen, palette.rgbBlue, -1));
+      colorData.push(this.mapRGBA(palette.rgbRed, palette.rgbGreen, palette.rgbBlue, -1, asRgbObj));
     }
     return colorData;
   }
@@ -575,7 +582,7 @@ Bitmap.prototype.mapColor = function(bmpBuf, bitCount){
       b = bmpBuf[i];
       g = bmpBuf[i + 1];
       r = bmpBuf[i + 2];
-      colorData.push(this.mapRGBA(r, g, b, -1));
+      colorData.push(this.mapRGBA(r, g, b, -1, asRgbObj));
     }
     return colorData;
   }
@@ -584,7 +591,7 @@ Bitmap.prototype.mapColor = function(bmpBuf, bitCount){
       b = bmpBuf[i];
       g = bmpBuf[i + 1];
       r = bmpBuf[i + 2];
-      colorData.push(this.mapRGBA(r, g, b, -1));
+      colorData.push(this.mapRGBA(r, g, b, -1, asRgbObj));
     }
     return colorData;
   }
@@ -594,7 +601,7 @@ Bitmap.prototype.mapColor = function(bmpBuf, bitCount){
       g = bmpBuf[i + 1];
       r = bmpBuf[i + 2];
       a = bmpBuf[i + 3];
-      colorData.push(this.mapRGBA(r, g, b, a));
+      colorData.push(this.mapRGBA(r, g, b, a, asRgbObj));
     }
     return colorData;
   }


### PR DESCRIPTION
In testing with a 4px square and 3px quare pure red image, the 3px had incorrect values, fixed
added option to return data as objects instead of strings
